### PR TITLE
Build Utilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,4 @@ rand = "0.3.15"
 vulkano = "0.3.1"
 
 [build-dependencies]
-# vulkano = "0.3.1"
 vulkano-shaders = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,5 @@ vulkano = "0.3.1"
 rand = "0.3.15"
 
 [build-dependencies]
+# vulkano = "0.3.1"
 vulkano-shaders = "0.3.1"

--- a/src/build_utils.rs
+++ b/src/build_utils.rs
@@ -1,0 +1,168 @@
+//! This module exports shader building tools which simplify the shader test building process.
+
+use std::path::Path;
+use std::fs::create_dir_all;
+
+/// Concatenates GLSL source files inserting `#line` statements where necessary.
+///
+/// # Motivation
+///
+/// To reuse/reduce duplicate code in shaders and to be able to test certain code parts of shader
+/// programs without updating both the actual shaders and the test shaders, one can split the
+/// shaders into semantically grouped parts, so-called segments. Prior to building the shaders the
+/// build script will have to concatenate the files. Without additional measures the errors of the
+/// shader compiler would point to the generated files/lines. Therefore we insert the `#line`
+/// macros which set the correct file name and line number.
+///
+/// # Panics
+///
+/// * If no files were given.
+/// * If the target directory cannot be created.
+/// * It a file cannot be opened.
+/// * Some other file I/O operations fail.
+///
+/// # Example
+///
+/// ```
+/// use std::fs::{create_dir_all, File};
+/// use std::io::{BufRead, BufReader};
+/// use std::path::Path;
+/// use vulkanology::build_utils::concatenate_files;
+///
+/// // Inputs
+/// let target = Path::new("target");
+/// let path_a = target.join("a.in").to_path_buf();
+/// let path_b = target.join("b.in").to_path_buf();
+/// create_dir_all(target).unwrap();
+///
+/// // Outputs
+/// let path_c = target.join("c.out");
+/// 
+/// // Concatenate the files.
+/// concatenate_files(&[path_a, path_b], &path_c);
+///
+/// // Check whether the resulting file contains both of the input files and a `#line` pragma.
+/// let input_files = [path_a, path_b];
+/// let mut file_c = File::open(path_c).unwrap();
+/// let mut lines_c = BufReader::new(&file_c);
+/// 
+/// fn contains_file(a: &mut BufReader<&File>, b: &mut BufReader<&File>) {
+///     for (line_a, line_b) in a.lines().zip(b.lines()) {
+///         assert_eq!(line_a.unwrap(), line_b.unwrap());
+///     }
+/// }
+///
+/// for input_file in &input_files {
+///     let mut file_input = File::open(input_file).unwrap();
+///     let mut lines_input = BufReader::new(&file_input);
+///
+///     contains_file(&mut lines_c, &mut lines_input);
+/// }
+/// 
+/// ```
+pub fn concatenate_files<P: AsRef<Path>>(file_names: &[P], write_to: &Path) {
+    if file_names.len() == 0 {
+        panic!("There must be at least one file to concatenate.");
+    }
+
+    use std::io::{Read, Write};
+    use std::fs::File;
+
+    // Each segment (.comp file) content is prefixed with the #line pragma. This makes the error
+    // messages be displayed with their filename and actual line number instead of the position of
+    // a line in the concatenated file.
+    let line_pragma = b"#line 1 \"";
+    let quotes = b"\"\n";
+
+    let target_dir = write_to.parent().unwrap();
+    create_dir_all(target_dir).expect("Failed to create target directory.");
+    let mut file_out = File::create(write_to)
+        .expect(format!("Failed to open output file: {}", write_to.display()).as_ref());
+    let mut file_names_iter = file_names.iter();
+
+    fn append_file(file_out: &mut File, file_name: &Path) {
+        let mut file_in = match File::open(file_name) {
+            Ok(file) => file,
+            Err(err) => {
+                panic!("Failed to open input file: {}\n{}",
+                       file_name.display(),
+                       err)
+            }
+        };
+
+        // Rerun the build script if one of the files changed
+        // for reference see: http://doc.crates.io/build-script.html#outputs-of-the-build-script
+        println!("cargo:rerun-if-changed={}", file_name.display());
+        let mut buffer = Vec::new();
+        file_in.read_to_end(&mut buffer).expect("Failed to read from file.");
+        file_out.write_all(&buffer).expect("Failed to write to file.");
+    }
+
+    // Copy the first file without any preceeding pragmas
+    let first_file = file_names_iter.next().unwrap();
+    append_file(&mut file_out, first_file.as_ref());
+
+    for file_name in file_names_iter {
+        let file_name_path = file_name.as_ref();
+        let file_name_bytes = file_name_path.to_str().unwrap().as_bytes();
+        file_out.write_all(line_pragma).expect("Failed to insert line pragma.");
+        file_out.write_all(file_name_bytes).expect("Failed to write file name.");
+        file_out.write_all(quotes).expect("Failed to write closing quotes.");
+        append_file(&mut file_out, file_name_path);
+    }
+}
+
+/// A simple macro for generating the code which compiles test shaders.
+/// * `$group_prefix` the prefix of the directory where tests for a particular UUT are located.
+/// * `$shader_name` the name of the shader test (should be a unique name).
+/// * `$segment` a list of shader segments to include between the header and the main.
+///
+/// The directory structure for a single shader test looks like the following:
+/// The files you have to provide are:
+/// `tests/something.rs` a regular rust integration test.
+/// `tests/shaders/<$group_prefix>/<$shader_name>_header.comp` - The test shader header.
+/// `tests/shaders/<$group_prefix>/<$shader_name>_main.comp` - The test shader main.
+/// `src/shaders/whatever.comp` - Some segments which the test shader includes and tests.
+///
+/// The GLSL files are then concatenated into a complete shader:
+/// `target/test_shaders/<$shader_name>.comp`
+///
+/// Finally these shaders are compiled and wrapped into Rust code which is located at:
+/// `<OUT_DIR>/shaders/target/test_shaders/<$shader_name>.comp`
+///
+///
+/// # Example
+///
+/// ```
+/// // The path to the normal shader segments.
+/// let src_shaders = Path::new("src/shaders");
+/// let random = src_shaders.join("random.comp");
+///
+/// // Tests for the random segment.
+/// let random_shaders = Path::new("random");
+///
+/// // next_u64().
+/// gen_simple_test_shader!{
+///     group_prefix: random_shaders,
+///     shader_name: test_random_next_u64,
+///     segments: [random.clone()]
+/// }
+/// ```
+macro_rules! gen_simple_test_shader {
+    (
+        group_prefix: $group_prefix:ident,
+        shader_name: $shader_name:ident,
+        segments: [ $( $segment:expr ),* ]
+    ) => {
+        let path_and_group = Path::new("tests/shaders").join($group_prefix);
+        let segments = [
+            path_and_group.join(concat!(stringify!($shader_name), "_header.comp")),
+            $( $segment, )*
+            path_and_group.join(concat!(stringify!($shader_name), "_main.comp"))
+        ];
+        let output = Path::new("target/test_shaders")
+            .join(concat!(stringify!($shader_name), ".comp"));
+        concatenate_files(&segments, &output);
+        let $shader_name = (output.to_str().unwrap(), ShaderType::Compute);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,7 +290,7 @@ macro_rules! cpu_array_buffer {
 macro_rules! pipeline {
     {
         shader_path: $shader_path:expr,
-        workgroup_count: [$workgroup_x:expr, $workgroup_y:expr, $workgroup_z:expr],
+        workgroup_count: $workgroup_count:expr,
         buffers: { $( $buf_ident:ident : [$buf_type:ty;$buf_len:expr] ),* },
         execution_command: $exec_cmd:ident
     } => {
@@ -343,9 +343,8 @@ macro_rules! pipeline {
                 .expect("Failed to create compute pipeline.");
 
         // Assemble and return the execution command.
-        let workgroup_count = [$workgroup_x, $workgroup_y, $workgroup_z];
         let execution_command = PrimaryCommandBufferBuilder::new(device, queue.family())
-            .dispatch(&pipeline, buffer_set, workgroup_count, &())
+            .dispatch(&pipeline, buffer_set, $workgroup_count, &())
             .build();
         let $exec_cmd = || {
             submit_command(&execution_command, queue).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,8 @@
 #[macro_reexport(pipeline_layout)]
 extern crate vulkano;
 
+pub mod build_utils;
+
 /// Creates a `vulkano::Instance`. Does not enable any instance extensions.
 ///
 /// # Panics

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,9 +48,6 @@
 #![deny(missing_docs)]
 #![feature(macro_reexport)]
 
-#[macro_reexport(pipeline_layout)]
-extern crate vulkano;
-
 pub mod build_utils;
 
 /// Creates a [`vulkano`] [`Instance`]. Does not enable any instance extensions.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,10 +34,14 @@
 //!
 //! This utility pack is built around the [`vulkano`] library, which also provides `vulkano-shaders`,
 //! a library which compiles GLSL shaders into Rust interface modules.
-//! For examples on how to build shaders with `vulkano-shaders` see:
-//! https://github.com/svenstaro/vulkanology/blob/master/build.rs
-//! https://github.com/tomaka/vulkano/blob/master/examples/build.rs
+//! For examples on how to build shaders with `vulkano-shaders` see `build.rs` and [this].
+//! 
+//! ## Composite shader tests
 //!
+//! `vulkanology` also provides some build utilities for working with segmented shaders.
+//! `src/build_utils.rs` contains working examples on how to use these utilities in your `build.rs`.
+//!
+//! [this]: https://github.com/tomaka/vulkano/blob/master/examples/build.rs
 //! [`vulkano`]: https://github.com/tomaka/vulkano
 //!
 #![deny(missing_docs)]
@@ -48,11 +52,11 @@ extern crate vulkano;
 
 pub mod build_utils;
 
-/// Creates a [`vulkano::instance::Instance`]. Does not enable any instance extensions.
+/// Creates a [`vulkano`] [`Instance`]. Does not enable any instance extensions.
 ///
 /// # Panics
 ///
-/// Panics if the vulkano instance loading procedure fails.
+/// Panics if the instance loading procedure fails.
 ///
 /// # Example
 ///
@@ -68,7 +72,8 @@ pub mod build_utils;
 /// # }
 /// ```
 ///
-/// [`vulkano::instance::Instance`]: https://docs.rs/vulkano/0.3.1/vulkano/instance/struct.Instance.html
+/// [`vulkano`]: https://github.com/tomaka/vulkano
+/// [`Instance`]: https://docs.rs/vulkano/0.3.1/vulkano/instance/struct.Instance.html
 ///
 #[macro_export]
 macro_rules! instance {
@@ -81,9 +86,7 @@ macro_rules! instance {
 
 /// This macro generates code for loading a [`PhysicalDevice`]. It takes
 /// the instance variable name and an optional list of features which the device
-/// should support.
-/// All available features are defined here:
-/// https://github.com/tomaka/vulkano/blob/master/vulkano/src/features.rs
+/// should support. All available features are defined [here].
 ///
 /// # Panics
 ///
@@ -116,6 +119,7 @@ macro_rules! instance {
 /// # }
 /// ```
 ///
+/// [here]: https://github.com/tomaka/vulkano/blob/master/vulkano/src/features.rs
 /// [`PhysicalDevice`]: https://docs.rs/vulkano/0.3.1/vulkano/instance/struct.PhysicalDevice.html
 ///
 #[macro_export]
@@ -142,7 +146,7 @@ macro_rules! physical_device {
 ///
 /// # Panics
 ///
-/// Panics if no conpute-compatible queue has been found, or the
+/// Panics if no compute-compatible queue has been found, or the
 /// device could not be initialized.
 ///
 /// # Example

--- a/tests/shaders/random/random_segment.comp
+++ b/tests/shaders/random/random_segment.comp
@@ -1,18 +1,3 @@
-#version 450
-#extension GL_ARB_gpu_shader_int64 : enable
-#extension GL_GOOGLE_cpp_style_line_directive : enable
-
-layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
-
-// Unique invocation id. Used to determine the index of the PRNG seed for this
-// invocation in `prng[]`.
-uint invocation_uid =
-    gl_GlobalInvocationID.y * gl_NumWorkGroups.x * gl_WorkGroupSize.x +
-    gl_GlobalInvocationID.x;
-
-layout(set = 0, binding = 0, std430) buffer PRNGSeed { uint64_t prng[]; };
-layout(set = 0, binding = 1, std430) buffer Result { uint64_t result[]; };
-
 // Rotate left operation on 64bit integers.
 // Rotates `x` by `k` positions to the left.
 uint64_t rotl64(const uint64_t x, const uint64_t k) {

--- a/tests/shaders/random/test_random_next_u64_header.comp
+++ b/tests/shaders/random/test_random_next_u64_header.comp
@@ -1,0 +1,14 @@
+#version 450
+#extension GL_ARB_gpu_shader_int64 : enable
+#extension GL_GOOGLE_cpp_style_line_directive : enable
+
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+
+// Unique invocation id. Used to determine the index of the PRNG seed for this
+// invocation in `prng[]`.
+uint invocation_uid =
+    gl_GlobalInvocationID.y * gl_NumWorkGroups.x * gl_WorkGroupSize.x +
+    gl_GlobalInvocationID.x;
+
+layout(set = 0, binding = 0, std430) buffer PRNGSeed { uint64_t prng[]; };
+layout(set = 0, binding = 1, std430) buffer Result { uint64_t result[]; };

--- a/tests/shaders/random/test_random_next_u64_main.comp
+++ b/tests/shaders/random/test_random_next_u64_main.comp
@@ -1,0 +1,6 @@
+void main(void) {
+    // This shader generates random numbers using the xoroshiro128+ PRNG.
+    // It modifies the seed. The seed of the invocation (x,y,1) is located
+    // `2.0 * (y * work_group_size.x * work_group_count.x + x)`.
+    result[invocation_uid] = xoroshiro128plus();
+}


### PR DESCRIPTION
This PR adds build utilities which simplify writing tests for segmanted shaders. The two main features are:
* concatenate_files: A function which concatenates GLSL shader segments.
It is used to split shaders into smaller parts.
Teese parts can be then be used in shader tests.

* gen_simple_test_shader: A wrapper macro for concatenate files. It defines a well-documented file/folder structure which further simplifies working with test shaders.
This macro is only usable for simple test shaders, which wrap a set of units under test with a header and a main.